### PR TITLE
Make 0-displacement move after tool change

### DIFF
--- a/gpx.c
+++ b/gpx.c
@@ -2827,6 +2827,7 @@ static int do_tool_change(Gpx *gpx, int timeout) {
     }
     // change current toolhead in order to apply the calibration offset
     CALL( change_extruder_offset(gpx, gpx->target.extruder) );
+    CALL( queue_absolute_point(gpx) );
     // set current extruder so changes in E are expressed as changes to A or B
     gpx->current.extruder = gpx->target.extruder;
     return SUCCESS;


### PR DESCRIPTION
Just a one-liner change to make a 0-displacement move in the generated x3g directly after a tool change.
