### PR TITLE
Windows serial I/O without a cygwin dependency

### DIFF
--- a/src/defines/defines.mk
+++ b/src/defines/defines.mk
@@ -60,6 +60,17 @@ OBJ = .o
 DEP = .d
 PYTHON =
 
+else ifeq ($(findstring CYGWIN,$(UNAME_OS)), CYGWIN)
+
+CC = gcc
+CC_FLAGS =
+LD_FLAGS =
+PLATFORM = win32
+EXE = .exe
+OBJ = .o
+DEP = .d
+PYTHON =
+
 else
 
 $(error Unsupported build platform $(UNAME_OS))

--- a/src/defines/defines.mk
+++ b/src/defines/defines.mk
@@ -52,7 +52,7 @@ PYTHON = python
 else ifeq ($(findstring MINGW32,$(UNAME_OS)), MINGW32)
 
 CC = gcc
-CC_FLAGS =
+CC_FLAGS = -DHAS_NANOSLEEP
 LD_FLAGS =
 PLATFORM = win32
 EXE = .exe
@@ -63,7 +63,7 @@ PYTHON =
 else ifeq ($(findstring CYGWIN,$(UNAME_OS)), CYGWIN)
 
 CC = gcc
-CC_FLAGS =
+CC_FLAGS = -DHAS_NANOSLEEP
 LD_FLAGS =
 PLATFORM = win32
 EXE = .exe

--- a/src/gpx/Makefile
+++ b/src/gpx/Makefile
@@ -8,17 +8,18 @@ include $(SRCDIR)/defines/defines.mk
 
 EXE_TARGETS = gpx
 
-gpx_SRCS = gpx.c gpx-main.c config.c opt.c $(EXTRA_SRCS)
+ifeq ($(PLATFORM), win32)
+SIO_SRCS = winsio.c
+endif
+ifeq ($(PLATFORM), win64)
+SIO_SRCS = winsio.c
+endif
+
+gpx_SRCS = gpx.c gpx-main.c config.c opt.c $(EXTRA_SRCS) $(SIO_SRCS)
 gpx_OBJS = $(notdir $(gpx_SRCS:.c=$(OBJ)))
 gpx_LIBS = m
 
-ifeq ($(PLATFORM), osx)
 gpx-main_DEFS = -DSERIAL_SUPPORT
-endif
-
-ifeq ($(PLATFORM), linux)
-gpx-main_DEFS = -DSERIAL_SUPPORT
-endif
 
 ifdef PYTHON
 ifdef DIFF

--- a/src/gpx/gpx.c
+++ b/src/gpx/gpx.c
@@ -5336,7 +5336,7 @@ static int port_handler(Gpx *gpx, Sio *sio, char *buffer, size_t length)
             }
             // check response code
             rval = gpx->buffer.in[2];
-            switch((unsigned)gpx->buffer.in[2]) {
+            switch((unsigned char)gpx->buffer.in[2]) {
                     // 0x80 - Generic Packet error, packet discarded (retry)
                 case 0x80:
                     VERBOSE( fprintf(gpx->log, "(retry %u) Generic Packet error: packet discarded" EOL, retry_count) );

--- a/src/gpx/gpx.h
+++ b/src/gpx/gpx.h
@@ -74,6 +74,9 @@ extern "C" {
 
 #define MAX_TIMEOUT 0xFFFF
 
+#if defined(_WIN32) || defined(_WIN64)
+typedef long speed_t;
+#endif
 #ifdef _WIN32
 #   define PATH_DELIM '\\'
 #   define EOL "\r\n"

--- a/src/gpx/winsio.c
+++ b/src/gpx/winsio.c
@@ -1,0 +1,88 @@
+//
+//  winsio.c
+//
+//  winsio - allow serial I/O without a cygwin dependency
+//  added to gpx markwal 5/8/2015
+//
+//  GPX originally created by WHPThomas <me(at)henri(dot)net> on 1/04/13.
+//
+//  gpx is Copyright (c) 2013 WHPThomas, All rights reserved.
+//
+//  gpx references ReplicatorG sources from /src/replicatorg/drivers
+//  which are part of the ReplicatorG project - http://www.replicat.org
+//  Copyright (c) 2008 Zach Smith
+//  and Makerbot4GSailfish.java Copyright (C) 2012 Jetty / Dan Newman
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software Foundation,
+//  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#include <windows.h>
+#include <io.h>
+#undef ERROR
+
+#include "winsio.h"
+#include "gpx.h"
+
+
+int gpx_sio_open(Gpx *gpx, const char *filename, speed_t baud_rate, int *sio_port)
+{
+    HANDLE h = CreateFile(filename, GENERIC_READ | GENERIC_WRITE, 0, 0,
+            OPEN_EXISTING, 0, 0);
+    if (h == INVALID_HANDLE_VALUE) {
+        fprintf(gpx->log, "Error opening port");
+        return 0;
+    }
+    *sio_port = _open_osfhandle((intptr_t)h, 0);
+
+    DCB dcb = {0};
+    dcb.DCBlength = sizeof(dcb);
+    if (!GetCommState(h, &dcb)) {
+        fprintf(gpx->log, "Error getting port attributes");
+        return 0;
+    }
+
+    dcb.BaudRate = baud_rate;
+    dcb.ByteSize=8;
+    dcb.StopBits=ONESTOPBIT;
+    dcb.Parity=NOPARITY;
+    if (!SetCommState(h, &dcb)) {
+        fprintf(gpx->log, "Error setting port attributes");
+        return 0;
+    }
+
+    COMMTIMEOUTS timeouts={0};
+    timeouts.ReadIntervalTimeout=50;
+    timeouts.ReadTotalTimeoutConstant=10;
+    timeouts.ReadTotalTimeoutMultiplier=50;
+    timeouts.WriteTotalTimeoutMultiplier=10;
+    if (!SetCommTimeouts(h, &timeouts)) {
+        fprintf(gpx->log, "Error setting port timeouts");
+        return 0;
+    }
+
+    // not sure best way to flush the read buffer without tcflush
+    printf("reading bytes\n");
+    unsigned char buffer[128];
+    size_t bytes;
+    while ((bytes = read(*sio_port, buffer, sizeof(buffer))) > 0) {
+        unsigned char *p = buffer;
+        while (bytes--)
+            printf("%02x ", (unsigned)*p++);
+    }
+    printf("\ngot rval = %ld\n", (long)bytes);
+
+    if(gpx->flag.verboseMode) fprintf(gpx->log, "Communicating via: %s" EOL, filename);
+    return 1;
+}

--- a/src/gpx/winsio.h
+++ b/src/gpx/winsio.h
@@ -1,0 +1,39 @@
+//
+//  winsio.h
+//
+//  winsio - allow serial I/O without a cygwin dependency
+//  added to gpx markwal 5/8/2015
+//
+//  GPX originally created by WHPThomas <me(at)henri(dot)net> on 1/04/13.
+//
+//  gpx is Copyright (c) 2013 WHPThomas, All rights reserved.
+//
+//  gpx references ReplicatorG sources from /src/replicatorg/drivers
+//  which are part of the ReplicatorG project - http://www.replicat.org
+//  Copyright (c) 2008 Zach Smith
+//  and Makerbot4GSailfish.java Copyright (C) 2012 Jetty / Dan Newman
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software Foundation,
+//  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+#define B0 0
+#define B4800 4800
+#define B9600 9600
+#define B14400 14400
+#define B19200 19200
+#define B28800 28800
+#define B38400 38400
+#define B57600 57600
+#define B115200 115200
+typedef long speed_t;


### PR DESCRIPTION
Couple of extra commits:
one that allows the cygwin build.  I actually use the mingw gcc when running under cygwin, but I also tested on Kubuntu.
another that defines HAS_NANOSLEEP for mingw and cygwin.
