### PR TITLE
Add intercharacter timeout

### DIFF
--- a/src/gpx/gpx-main.c
+++ b/src/gpx/gpx-main.c
@@ -264,6 +264,12 @@ int gpx_sio_open(Gpx *gpx, const char *filename, speed_t baud_rate, int *sio_por
     // cfsetispeed(&tp, baud_rate);
     // cfsetospeed(&tp, baud_rate);
 
+    // let's ask the i/o system to block for up to a tenth of a second
+    // waiting for at least 255 bytes or whatever we asked for (whichever
+    // is least).
+    tp.c_cc[VMIN] = 255;
+    tp.c_cc[VTIME] = 1;
+
     if(tcsetattr(sio_port, TCSANOW, &tp) < 0) {
         perror("Error setting port attributes");
         exit(-1);


### PR DESCRIPTION
Before this change, I believe the default is VMIN=0, VTIME=0 which means that
when calling read, you get whatever is available right then. The gpx code
handles the no bytes came back case fairly well, ish. But doesn't always expect
less than asked. The proposed setting here will only return less than asked when
it is 255 characters or more or the intercharacter timeout of one decisecond is
exceeded which emperically works much more reliably (at least at 115200 baud).
